### PR TITLE
Exit the process with error code when unhandled rejection

### DIFF
--- a/commands/lib/log.js
+++ b/commands/lib/log.js
@@ -13,13 +13,13 @@ process.on('uncaughtException',
             return
         }
 
-        setTimeout(() => { process.abort() }, 1000).unref()
         process.exit(1);
     });
 
 process.on('unhandledRejection',
     (err) => {
-        log.error(err, 'Unhandled Promise Rejection');
+        log.fatal(err, 'Unhandled Promise Rejection');
+        process.exit(1);
     });
 
 export default log


### PR DESCRIPTION
Running `whcli` with, for example, an invalid token, exits with 0, e.g.:

```
whcli forward --token=faceb236-ad99-463c-bd78-57e872d18b31 --target=http://localhost
```

This PR adds a `process.exit(1);` to the `unhandledRejection` handler, which is the default behavior in Node.js.
Also, I removed the `process.abort()` which I think is never called because the following `process.exit` runs right away.