### PR TITLE
Remove the header transfer-encoding on requests

### DIFF
--- a/commands/forward.js
+++ b/commands/forward.js
@@ -68,7 +68,8 @@ export default async (argv) => {
 
             const removeHeaders = [
                 'host',
-                'content-length'
+                'content-length',
+                'transfer-encoding'
             ]
 
             for (let headerName of removeHeaders) {


### PR DESCRIPTION
When the header `transfer-encoding` with the any of the values set: `chunked`, `compress`, `deflate`, `gzip`, the host that receive the request will return bad request to the cli-client, because of that the data isn't streamed.